### PR TITLE
Default components

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ Components covered -
 - [Combobox (Autocomplete)](https://headlessui.com/react/combobox)
 - [Radio Group](https://headlessui.com/react/radio-group)
 
+Refer the following [blogpost](https://dev.to/binarysingh/how-to-use-headlessui-with-react-hook-form-5dhe) for more details
+
 ## Good to know
 
 The headless ui components like combobox and radio group use an array of options and each option in this array is an object. By default, headless ui sends you the complete information of selected option i.e the complete object of the selected option. But, it is very rare that you'll need this. So, I have modified the components to return only the value of the selected option instead of complete object. If you want to stick to the default behaviou you can use the default components i.e, ComboBoxDefault and RadioGroupDefault.
@@ -17,7 +19,7 @@ I also noticed a class "select-none" added to <Combobox.Option /> which caused i
 
 ## Demo
 
-A working demo for the same can be found at []()
+A working demo for the same can be found at [https://rhf-with-headlessui.vercel.app](https://rhf-with-headlessui.vercel.app)
 
 This project is deployed using the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 

--- a/components/formElements/ComboBox.tsx
+++ b/components/formElements/ComboBox.tsx
@@ -4,7 +4,7 @@ import { CheckIcon, ChevronUpDownIcon } from "@heroicons/react/20/solid";
 import { FieldError } from "react-hook-form";
 
 export default function ComboBoxWrapper({
-  value,
+  value = '',
   onChange,
   onBlur,
   label,
@@ -42,7 +42,7 @@ export default function ComboBoxWrapper({
         <Combobox.Label className="block text-sm font-medium leading-6 text-gray-900 mt-6">
           {label}
         </Combobox.Label>
-        <div className="relative mt-1">
+        <div className="relative mt-3">
           <div className="relative w-full cursor-default overflow-hidden rounded-lg bg-white text-left shadow-md focus:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-opacity-75 focus-visible:ring-offset-2 focus-visible:ring-offset-orange-300 sm:text-sm">
             <Combobox.Button className="w-full inset-y-0 right-0 flex items-center pr-2">
               <Combobox.Input

--- a/components/formElements/ComboBoxDefault.tsx
+++ b/components/formElements/ComboBoxDefault.tsx
@@ -1,0 +1,121 @@
+import { Fragment, useState } from "react";
+import { Combobox, Transition } from "@headlessui/react";
+import { CheckIcon, ChevronUpDownIcon } from "@heroicons/react/20/solid";
+import { FieldError } from "react-hook-form";
+
+type OptionType = {
+  value: string | number;
+  label: string;
+  id: number | string;
+};
+
+type ValueType = OptionType | {};
+
+export default function ComboBoxDefaultWrapper({
+  value = {},
+  onChange,
+  onBlur,
+  label,
+  options,
+  error,
+}: {
+  value: ValueType;
+  onChange: any;
+  onBlur: any;
+  label: string;
+  options: OptionType[];
+  error: FieldError | undefined;
+}) {
+  const [query, setQuery] = useState("");
+
+  const filteredOptions =
+    query === ""
+      ? options
+      : options.filter((option) => {
+          return option.label.toLowerCase().includes(query.toLowerCase());
+        });
+
+  const getValue = (val: ValueType) => {
+    return "id" in val ? options.find((option) => option.id === val.id) : val;
+  };
+
+  return (
+    <>
+      <Combobox value={getValue(value)} onChange={onChange} nullable>
+        <Combobox.Label className="block text-sm font-medium leading-6 text-gray-900 mt-6">
+          {label}
+        </Combobox.Label>
+        <div className="relative mt-3">
+          <div className="relative w-full cursor-default overflow-hidden rounded-lg bg-white text-left shadow-md focus:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-opacity-75 focus-visible:ring-offset-2 focus-visible:ring-offset-orange-300 sm:text-sm">
+            <Combobox.Button className="w-full inset-y-0 right-0 flex items-center pr-2">
+              <Combobox.Input
+                className="w-full border-none py-2 pl-3 pr-10 text-sm leading-5 text-gray-900 focus:ring-0"
+                onChange={(event) => setQuery(event.target.value)}
+                displayValue={(option: OptionType) => option.label}
+                placeholder="Start typing to search..."
+                onBlur={onBlur}
+              />
+              <ChevronUpDownIcon
+                className="h-5 w-5 text-gray-400"
+                aria-hidden="true"
+              />
+            </Combobox.Button>
+          </div>
+          <Transition
+            as={Fragment}
+            leave="transition ease-in duration-100"
+            leaveFrom="opacity-100"
+            leaveTo="opacity-0"
+            afterLeave={() => setQuery("")}
+          >
+            <Combobox.Options className="absolute mt-1 max-h-60 w-full overflow-auto rounded-md bg-white py-1 text-base shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none sm:text-sm">
+              {filteredOptions.length === 0 && query !== "" ? (
+                <div className="relative cursor-default select-none py-2 px-4 text-gray-700">
+                  Nothing found.
+                </div>
+              ) : (
+                filteredOptions.map((option) => (
+                  <Combobox.Option
+                    key={option.id}
+                    className={({ active }) =>
+                      `relative cursor-default py-2 pl-10 pr-4 ${
+                        active ? "bg-orange-600 text-white" : "text-gray-900"
+                      }`
+                    }
+                    value={option}
+                  >
+                    {({ selected, active }) => (
+                      <>
+                        <span
+                          className={`block truncate ${
+                            selected ? "font-medium" : "font-normal"
+                          }`}
+                        >
+                          {option.label}
+                        </span>
+                        {selected ? (
+                          <span
+                            className={`absolute inset-y-0 left-0 flex items-center pl-3 ${
+                              active ? "text-white" : "text-orange-600"
+                            }`}
+                          >
+                            <CheckIcon className="h-5 w-5" aria-hidden="true" />
+                          </span>
+                        ) : null}
+                      </>
+                    )}
+                  </Combobox.Option>
+                ))
+              )}
+            </Combobox.Options>
+          </Transition>
+        </div>
+      </Combobox>
+      {error && (
+        <p className="mt-2 text-sm text-red-600" id="email-error">
+          {error.message}
+        </p>
+      )}
+    </>
+  );
+}

--- a/components/formElements/RadioGroup.tsx
+++ b/components/formElements/RadioGroup.tsx
@@ -3,7 +3,7 @@ import { FieldError } from "react-hook-form";
 
 export default function RadioGroupWrapper({
   label,
-  value,
+  value = '',
   onChange,
   options,
   onBlur,

--- a/components/formElements/RadioGroupDefault.tsx
+++ b/components/formElements/RadioGroupDefault.tsx
@@ -1,0 +1,115 @@
+import { RadioGroup } from "@headlessui/react";
+import { FieldError } from "react-hook-form";
+
+type OptionData = {
+  id: number | string;
+  value: string;
+  label: string;
+  desc: string;
+};
+
+type ValueType = OptionData | {};
+
+export default function RadioGroupDefaultWrapper({
+  label,
+  value = {},
+  onChange,
+  options,
+  onBlur,
+  error,
+}: {
+  label: string;
+  value: ValueType;
+  onChange: any;
+  onBlur: any;
+  options: OptionData[];
+  error: FieldError | undefined;
+}) {
+
+  const getValue = (val: ValueType) => {
+    return "id" in val ? options.find((option) => option.id === val.id) : val;
+  };
+
+  return (
+    <>
+      <RadioGroup value={getValue(value)} onChange={onChange} onBlur={onBlur}>
+        <RadioGroup.Label className="text-base font-semibold leading-6 text-gray-900">
+          {label}
+        </RadioGroup.Label>
+        <div className="space-y-2 mt-4">
+          {options.map((option) => (
+            <RadioGroup.Option
+              key={option.id}
+              value={option}
+              className={({ active, checked }) =>
+                `${
+                  active
+                    ? "ring-2 ring-white ring-opacity-60 ring-offset-2 ring-offset-orange-300"
+                    : ""
+                }
+                  ${
+                    checked
+                      ? "bg-orange-900 bg-opacity-75 text-white"
+                      : "bg-white"
+                  }
+                    relative flex cursor-pointer rounded-lg px-5 py-2 shadow-md focus:outline-none`
+              }
+            >
+              {({ checked }) => (
+                <>
+                  <div className="flex w-full items-center justify-between">
+                    <div className="flex items-center">
+                      <div className="text-sm">
+                        <RadioGroup.Label
+                          as="p"
+                          className={`font-medium  ${
+                            checked ? "text-white" : "text-gray-900"
+                          }`}
+                        >
+                          {option.label}
+                        </RadioGroup.Label>
+                        <RadioGroup.Description
+                          as="span"
+                          className={`inline ${
+                            checked ? "text-orange-100" : "text-gray-500"
+                          }`}
+                        >
+                          <span>{option.desc}</span>
+                        </RadioGroup.Description>
+                      </div>
+                    </div>
+                    {checked && (
+                      <div className="shrink-0 text-white">
+                        <CheckIcon className="h-6 w-6" />
+                      </div>
+                    )}
+                  </div>
+                </>
+              )}
+            </RadioGroup.Option>
+          ))}
+        </div>
+      </RadioGroup>
+      {error && (
+        <p className="mt-2 text-sm text-red-600" id="email-error">
+          {error.message}
+        </p>
+      )}
+    </>
+  );
+}
+
+function CheckIcon(props: React.ComponentProps<"svg">) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" {...props}>
+      <circle cx={12} cy={12} r={12} fill="#fff" opacity="0.2" />
+      <path
+        d="M7 13l3 3 7-7"
+        stroke="#fff"
+        strokeWidth={1.5}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}

--- a/components/layout/ColContainer.tsx
+++ b/components/layout/ColContainer.tsx
@@ -4,7 +4,7 @@ export default function ColContainer({
   children: React.ReactNode;
 }) {
   return (
-    <div className="group rounded-lg border border-transparent px-5 py-4 transition-colors hover:border-gray-300 hover:bg-gray-100 hover:dark:border-neutral-700 hover:dark:bg-neutral-800/30">
+    <div className="group rounded-lg border border-transparent px-5 py-4 transition-colors hover:border-gray-300 hover:bg-gray-100">
       {children}
     </div>
   );

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -2,13 +2,17 @@ import { CodeBracketIcon, DocumentTextIcon } from "@heroicons/react/24/outline";
 
 export default function Header() {
   return (
-    <header className="fixed sm:relative top-0 z-10 p-4 border-b border-gray-300 bg-gradient-to-b font-mono from-zinc-200 backdrop-blur-2xl dark:border-neutral-800 dark:bg-zinc-800/30 dark:from-inherit lg:static lg:w-auto  lg:rounded-xl lg:border lg:bg-gray-200 lg:dark:bg-zinc-800/30 flex justify-between">
+    <header className="fixed sm:relative top-0 z-10 p-4 border-b border-gray-300 bg-gradient-to-b font-mono from-zinc-200 backdrop-blur-2xl lg:static lg:w-auto  lg:rounded-xl lg:border lg:bg-gray-200 flex justify-between">
       <code className="font-mono font-bold">
         React hook form with headlessui components
       </code>
       <div className="w-28 text-right">
-        <CodeBracketIcon className="h-6 w-6 cursor-pointer hover:bg-gray-300 rounded-md p-0.5 inline-block" />
-        <DocumentTextIcon className="h-6 w-6 cursor-pointer hover:bg-gray-300 rounded-md p-0.5 inline-block sm:mx-4 ml-4" />
+        <a href="https://github.com/singhBinary/rhf-with-headlessui">
+          <CodeBracketIcon className="h-6 w-6 cursor-pointer hover:bg-gray-300 rounded-md p-0.5 inline-block" />
+        </a>
+        <a href="https://dev.to/binarysingh/how-to-use-headlessui-with-react-hook-form-5dhe">
+          <DocumentTextIcon className="h-6 w-6 cursor-pointer hover:bg-gray-300 rounded-md p-0.5 inline-block sm:mx-4 ml-4" />
+        </a>
       </div>
     </header>
   );

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,8 @@
         "typescript": "5.0.4"
       },
       "devDependencies": {
-        "@tailwindcss/forms": "^0.5.3"
+        "@tailwindcss/forms": "^0.5.3",
+        "@types/nprogress": "^0.2.0"
       }
     },
     "node_modules/@babel/runtime": {
@@ -426,6 +427,12 @@
       "version": "18.15.11",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.11.tgz",
       "integrity": "sha512-E5Kwq2n4SbMzQOn6wnmBjuK9ouqlURrcZDVfbo9ftDDTFt3nk7ZKK4GMOzoYgnpQJKcxwQw+lGaBvvlMo0qN/Q=="
+    },
+    "node_modules/@types/nprogress": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@types/nprogress/-/nprogress-0.2.0.tgz",
+      "integrity": "sha512-1cYJrqq9GezNFPsWTZpFut/d4CjpZqA0vhqDUPFWYKF1oIyBz5qnoYMzR+0C/T96t3ebLAC1SSnwrVOm5/j74A==",
+      "dev": true
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.5",
@@ -4263,6 +4270,12 @@
       "version": "18.15.11",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.11.tgz",
       "integrity": "sha512-E5Kwq2n4SbMzQOn6wnmBjuK9ouqlURrcZDVfbo9ftDDTFt3nk7ZKK4GMOzoYgnpQJKcxwQw+lGaBvvlMo0qN/Q=="
+    },
+    "@types/nprogress": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@types/nprogress/-/nprogress-0.2.0.tgz",
+      "integrity": "sha512-1cYJrqq9GezNFPsWTZpFut/d4CjpZqA0vhqDUPFWYKF1oIyBz5qnoYMzR+0C/T96t3ebLAC1SSnwrVOm5/j74A==",
+      "dev": true
     },
     "@types/prop-types": {
       "version": "15.7.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "eslint": "8.38.0",
         "eslint-config-next": "13.3.0",
         "next": "13.3.0",
+        "nprogress": "^0.2.0",
         "postcss": "8.4.21",
         "react": "18.2.0",
         "react-dom": "18.2.0",
@@ -2784,6 +2785,11 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/nprogress": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/nprogress/-/nprogress-0.2.0.tgz",
+      "integrity": "sha512-I19aIingLgR1fmhftnbWWO3dXc0hSxqHQHQb3H8m+K3TnEn/iSeTZZOyvKXWqQESMwuUVnatlCnZdLBZZt2VSA=="
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
@@ -5894,6 +5900,11 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
       "integrity": "sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA=="
+    },
+    "nprogress": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/nprogress/-/nprogress-0.2.0.tgz",
+      "integrity": "sha512-I19aIingLgR1fmhftnbWWO3dXc0hSxqHQHQb3H8m+K3TnEn/iSeTZZOyvKXWqQESMwuUVnatlCnZdLBZZt2VSA=="
     },
     "object-assign": {
       "version": "4.1.1",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "typescript": "5.0.4"
   },
   "devDependencies": {
-    "@tailwindcss/forms": "^0.5.3"
+    "@tailwindcss/forms": "^0.5.3",
+    "@types/nprogress": "^0.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "eslint": "8.38.0",
     "eslint-config-next": "13.3.0",
     "next": "13.3.0",
+    "nprogress": "^0.2.0",
     "postcss": "8.4.21",
     "react": "18.2.0",
     "react-dom": "18.2.0",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,6 +1,32 @@
-import '../styles/globals.css'
-import type { AppProps } from 'next/app'
+import { useEffect } from 'react'
+import type { AppProps } from "next/app";
+import { useRouter } from "next/router";
+import NProgress from "nprogress";
+
+import "../styles/globals.css";
 
 export default function App({ Component, pageProps }: AppProps) {
-  return <Component {...pageProps} />
+  const router = useRouter();
+
+  useEffect(() => {
+    const handleStart = (url: string) => {
+      console.log(`Loading: ${url}`);
+      NProgress.start();
+    };
+
+    const handleStop = () => {
+      NProgress.done();
+    };
+
+    router.events.on("routeChangeStart", handleStart);
+    router.events.on("routeChangeComplete", handleStop);
+    router.events.on("routeChangeError", handleStop);
+
+    return () => {
+      router.events.off("routeChangeStart", handleStart);
+      router.events.off("routeChangeComplete", handleStop);
+      router.events.off("routeChangeError", handleStop);
+    };
+  }, [router]);
+  return <Component {...pageProps} />;
 }

--- a/pages/default.tsx
+++ b/pages/default.tsx
@@ -3,8 +3,8 @@ import { useForm, Controller } from "react-hook-form";
 import Link from "next/link";
 import { useRouter } from "next/router";
 
-import RadioGroupWrapper from "@/components/formElements/RadioGroup";
-import ComboBoxWrapper from "@/components/formElements/ComboBox";
+import RadioGroupDefaultWrapper from "@/components/formElements/RadioGroupDefault";
+import ComboBoxDefaultWrapper from "@/components/formElements/ComboBoxDefault";
 import Header from "@/components/layout/Header";
 import ColContainer from "@/components/layout/ColContainer";
 import ColHeading from "@/components/layout/ColHeading";
@@ -15,7 +15,27 @@ type FormData = {
   user: string;
 };
 
-export default function Home() {
+const comboBoxOptions = [
+  { id: 1, label: "Wade Cooper", value: "wade" },
+  { id: 2, label: "Arlene Mccoy", value: "arlene" },
+];
+
+const radioGroupOptions = [
+  {
+    id: 1,
+    value: "startup",
+    label: "Startup",
+    desc: "12GB",
+  },
+  {
+    id: 2,
+    value: "business",
+    label: "Business",
+    desc: "16GB",
+  },
+];
+
+export default function DefaultBehaviour() {
   const router = useRouter();
   const { storage, user } = router.query;
 
@@ -34,9 +54,20 @@ export default function Home() {
   const storageWatch = watch("storage");
   const userWatch = watch("user");
 
+  const getValCorrespondingOption = (value: string, options: any[]) => {
+    const option = options.find((option) => option.value === value);
+    return option;
+  };
+
   useEffect(() => {
     if (storage && user) {
-      reset({ storage: storage as string, user: user as string });
+      reset({
+        storage: getValCorrespondingOption(
+          storage as string,
+          radioGroupOptions
+        ),
+        user: getValCorrespondingOption(user as string, comboBoxOptions),
+      });
     } else {
       reset({ storage: undefined, user: undefined });
     }
@@ -52,11 +83,12 @@ export default function Home() {
         options and each option in this array is an object. By default, headless
         ui sends you the complete information of selected option i.e the
         complete object of the selected option. But, it is very rare that you'll
-        need this. So, I have modified the components to return only the value
-        of the selected option instead of complete object. If you want to stick
-        to the default behaviou you can use the{" "}
-        <Link href="/default" className="text-orange-500">
-          default components
+        need this. So, I have also created a version of the components to return
+        only the value of the selected option instead of complete object. You
+        can check it out
+        <Link href="/" className="text-orange-500">
+          {" "}
+          here
         </Link>
       </p>
 
@@ -71,25 +103,12 @@ export default function Home() {
                 required: "Please select a storage option",
               }}
               render={({ field: { onChange, value, onBlur } }) => (
-                <RadioGroupWrapper
+                <RadioGroupDefaultWrapper
                   label="Radio Group"
                   value={value}
                   onChange={onChange}
                   onBlur={onBlur}
-                  options={[
-                    {
-                      id: 1,
-                      value: "startup",
-                      label: "Startup",
-                      desc: "12GB",
-                    },
-                    {
-                      id: 2,
-                      value: "business",
-                      label: "Business",
-                      desc: "16GB",
-                    },
-                  ]}
+                  options={radioGroupOptions}
                   error={errors.storage}
                 />
               )}
@@ -102,15 +121,12 @@ export default function Home() {
                 required: "Please select a user",
               }}
               render={({ field: { onChange, value, onBlur } }) => (
-                <ComboBoxWrapper
+                <ComboBoxDefaultWrapper
                   label="Combo Box"
                   value={value}
                   onChange={onChange}
                   onBlur={onBlur}
-                  options={[
-                    { id: 1, label: "Wade Cooper", value: "wade" },
-                    { id: 2, label: "Arlene Mccoy", value: "arlene" },
-                  ]}
+                  options={comboBoxOptions}
                   error={errors.user}
                 />
               )}
@@ -124,14 +140,14 @@ export default function Home() {
             </button>
             {storage && user ? (
               <Link
-                href="/"
+                href="/default"
                 className="rounded-md bg-white px-3.5 py-2.5 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50 ml-3"
               >
                 Without Prefill
               </Link>
             ) : (
               <Link
-                href="?storage=business&user=arlene"
+                href="/default?storage=business&user=arlene"
                 className="rounded-md bg-white px-3.5 py-2.5 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50 ml-3"
               >
                 Prefill

--- a/pages/default.tsx
+++ b/pages/default.tsx
@@ -72,7 +72,7 @@ export default function DefaultBehaviour() {
       reset({ storage: undefined, user: undefined });
     }
     setFormData({});
-  }, [storage, user]);
+  }, [storage, user, reset]);
 
   return (
     <main className="min-h-screen sm:px-24 sm:py-10 ">
@@ -82,7 +82,7 @@ export default function DefaultBehaviour() {
         The headless ui components like combobox and radio group use an array of
         options and each option in this array is an object. By default, headless
         ui sends you the complete information of selected option i.e the
-        complete object of the selected option. But, it is very rare that you'll
+        complete object of the selected option. But, it is very rare that you will
         need this. So, I have also created a version of the components to return
         only the value of the selected option instead of complete object. You
         can check it out

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -41,7 +41,7 @@ export default function Home() {
       reset({ storage: undefined, user: undefined });
     }
     setFormData({});
-  }, [storage, user]);
+  }, [storage, user, reset]);
 
   return (
     <main className="min-h-screen sm:px-24 sm:py-10 ">
@@ -51,7 +51,7 @@ export default function Home() {
         The headless ui components like combobox and radio group use an array of
         options and each option in this array is an object. By default, headless
         ui sends you the complete information of selected option i.e the
-        complete object of the selected option. But, it is very rare that you'll
+        complete object of the selected option. But, it is very rare that you will
         need this. So, I have modified the components to return only the value
         of the selected option instead of complete object. If you want to stick
         to the default behaviou you can use the{" "}
@@ -125,14 +125,14 @@ export default function Home() {
             {storage && user ? (
               <Link
                 href="/"
-                className="rounded-md bg-white px-3.5 py-2.5 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50 ml-3"
+                className="rounded-md bg-white px-3.5 py-2.5 text-sm font-semibold text-gray-900 shadow-sm hover:bg-gray-50 ml-3 border border-gray-300"
               >
                 Without Prefill
               </Link>
             ) : (
               <Link
                 href="?storage=business&user=arlene"
-                className="rounded-md bg-white px-3.5 py-2.5 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50 ml-3"
+                className="rounded-md bg-white px-3.5 py-2.5 text-sm font-semibold text-gray-900 shadow-sm hover:bg-gray-50 ml-3 border border-gray-300"
               >
                 Prefill
               </Link>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -8,14 +8,6 @@
   --background-end-rgb: 255, 255, 255;
 }
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    --foreground-rgb: 255, 255, 255;
-    --background-start-rgb: 0, 0, 0;
-    --background-end-rgb: 0, 0, 0;
-  }
-}
-
 body {
   color: rgb(var(--foreground-rgb));
   background: linear-gradient(
@@ -24,4 +16,35 @@ body {
       rgb(var(--background-end-rgb))
     )
     rgb(var(--background-start-rgb));
+}
+
+/* Make clicks pass-through */
+#nprogress {
+  pointer-events: none;
+}
+
+#nprogress .bar {
+  @apply bg-orange-500;
+  position: fixed;
+  z-index: 1031;
+  top: 0;
+  left: 0;
+
+  width: 100%;
+  height: 2px;
+}
+
+/* Fancy blur effect */
+#nprogress .peg {
+  display: block;
+  position: absolute;
+  right: 0px;
+  width: 100px;
+  height: 100%;
+  box-shadow: 0 0 10px theme('colors.orange.500'), 0 0 5px theme('colors.orange.500');
+  opacity: 1.0;
+
+  -webkit-transform: rotate(3deg) translate(0px, -4px);
+      -ms-transform: rotate(3deg) translate(0px, -4px);
+          transform: rotate(3deg) translate(0px, -4px);
 }


### PR DESCRIPTION
This PR contains
- Components with default behavior as headlessui where on selection of an option we get the whole option object.
- A new page at /default route depicting the usage of the above default components
- Added provision to prefill form with the help of query params
- Fixed typescript issues
- Added loader between page loads
- UI enhancements
- Readme updated